### PR TITLE
Add support for Artifactory Docker Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Docker Cache Buildkite Plugin [![Build status](https://badge.buildkite.com/a3851ab6b8e918f7a29d1d43fd8a410308fd5a50455b8a4ab3.svg)](https://buildkite.com/buildkite/plugins-docker-cache)
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for caching [Docker](https://docker.com) images across builds using various registry providers (ECR, GAR, and Buildkite Packages currently supported).
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for caching [Docker](https://docker.com) images across builds using various registry providers (ECR, GAR, Buildkite Packages, and Artifactory Docker Registry currently supported).
 
-This plugin speeds up your Docker builds by caching images between pipeline runs. Instead of rebuilding the same Docker image every time, it stores built images in ECR, Google Artifact Registry, or Buildkite Packages and reuses them when nothing has changed.
+This plugin speeds up your Docker builds by caching images between pipeline runs. Instead of rebuilding the same Docker image every time, it stores built images in ECR, Google Artifact Registry, Buildkite Packages, or Artifactory Docker Registry and reuses them when nothing has changed.
 
 The plugin will check if a cached version of your image already exists. If it does, it pulls that instead of rebuilding. If not, it builds the image and saves it for next time. It automatically creates the necessary repositories in your registry if they don't exist (ECR and GAR only - Buildkite Packages registries are managed through the UI).
 
@@ -75,6 +75,24 @@ steps:
           buildkite:
             org-slug: my-org
             auth-method: oidc
+```
+
+### Artifactory Docker Registry Provider
+
+The following pipeline will cache Docker builds in Artifactory Docker Registry:
+
+```yaml
+steps:
+  - label: "🐳 Build with Artifactory cache"
+    command: "echo 'Building with cache'"
+    plugins:
+      - docker-cache#v1.0.0:
+          provider: artifactory
+          image: my-app
+          artifactory:
+            registry-url: myjfroginstance.jfrog.io
+            username: me@example.com
+            identity-token: $ARTIFACTORY_IDENTITY_TOKEN
 ```
 
 ### Cache Strategies
@@ -176,7 +194,7 @@ These are all the options available to configure this plugin's behaviour.
 
 #### `provider` (string)
 
-Which registry provider to use for caching. Supported values: `ecr`, `gar`, `buildkite`.
+Which registry provider to use for caching. Supported values: `ecr`, `gar`, `buildkite`, `artifactory`.
 
 #### `image` (string)
 
@@ -345,6 +363,28 @@ Authentication method to use. Supported values: `api-token`, `oidc`.
 
 Buildkite API token with Read Packages and Write Packages scopes. Required when `auth-method` is `api-token`. Can also be provided via the `BUILDKITE_API_TOKEN` environment variable for backward compatibility.
 
+### Artifactory Provider Options
+
+**Note:** Authentication requires a username (typically email) and identity token from your Artifactory instance.
+
+When using `provider: artifactory`, these options are available:
+
+#### `artifactory.registry-url` (string, required)
+
+The Artifactory registry URL (e.g., `myjfroginstance.jfrog.io`). Do not include the protocol (`https://`).
+
+#### `artifactory.username` (string, required)
+
+The username for Artifactory authentication, typically your email address.
+
+#### `artifactory.identity-token` (string, required)
+
+The Artifactory identity token for authentication. Can reference an environment variable using `$VARIABLE_NAME` syntax.
+
+#### `artifactory.repository` (string)
+
+Artifactory repository name. If omitted, defaults to the image name.
+
 ## Authentication
 
 ### ECR Authentication
@@ -428,6 +468,7 @@ OIDC authentication requires:
 - Proper OIDC policy configuration in your Buildkite organization
 - Pipeline access to the target registry
 
+
 ## Cache Key Generation
 
 Cache keys are automatically generated from:
@@ -443,7 +484,7 @@ This ensures the cache is invalidated whenever anything that affects the build c
 
 | Elastic Stack | Agent Stack K8s | Hosted (Mac) | Hosted (Linux) | Notes |
 | :-----------: | :-------------: | :----------: | :------------: |:---- |
-| ✅ |  ✅ | ❌ | ✅ | **ECR** – Requires `awscli`<br/>**GAR** – Requires `gcloud`<br/>**Hosted (Mac)** – Docker engine not available |
+| ✅ |  ✅ | ❌ | ✅ | **ECR** – Requires `awscli`<br/>**GAR** – Requires `gcloud`<br/>**Buildkite Packages** – Requires `docker`<br/>**Artifactory** – Requires `docker`<br/>**Hosted (Mac)** – Docker engine not available |
 
 - ✅ Fully supported (all combinations of attributes have been tested to pass)
 - ⚠️ Partially supported (some combinations cause errors/issues)

--- a/hooks/environment
+++ b/hooks/environment
@@ -25,11 +25,11 @@ main() {
 
   # Validate provider
   case "${BUILDKITE_PLUGIN_DOCKER_CACHE_PROVIDER}" in
-    ecr|gar|buildkite)
+    ecr|gar|buildkite|artifactory)
       ;;
     *)
       log_error "unsupported provider '${BUILDKITE_PLUGIN_DOCKER_CACHE_PROVIDER}'"
-      log_info "Supported providers: ecr, gar, buildkite"
+      log_info "Supported providers: ecr, gar, buildkite, artifactory"
       exit 1
       ;;
   esac
@@ -50,6 +50,9 @@ main() {
       ;;
     buildkite)
       validate_buildkite_config
+      ;;
+    artifactory)
+      validate_artifactory_config
       ;;
   esac
 
@@ -205,6 +208,53 @@ validate_buildkite_config() {
     local registry_slug="${BUILDKITE_PLUGIN_DOCKER_CACHE_BUILDKITE_REGISTRY_SLUG}"
     if [[ ! "$registry_slug" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$ ]] || [[ ${#registry_slug} -lt 3 ]] || [[ ${#registry_slug} -gt 63 ]]; then
       log_error "invalid registry slug '${registry_slug}' - must be 3-63 characters, start and end with alphanumeric, contain only lowercase letters, numbers, and hyphens"
+      exit 1
+    fi
+  fi
+}
+
+validate_artifactory_config() {
+  # Validate registry URL is provided
+  if [[ -z "${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL:-}" ]]; then
+    log_error "Artifactory registry URL is required"
+    log_info "Set it via the 'artifactory.registry-url' parameter"
+    exit 1
+  fi
+
+  # Validate username is provided
+  if [[ -z "${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_USERNAME:-}" ]]; then
+    log_error "Artifactory username is required"
+    log_info "Set it via the 'artifactory.username' parameter"
+    exit 1
+  fi
+
+  # Validate identity token is provided
+  if [[ -z "${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_IDENTITY_TOKEN:-}" ]]; then
+    log_error "Artifactory identity token is required"
+    log_info "Set it via the 'artifactory.identity-token' parameter"
+    exit 1
+  fi
+
+  # Validate registry URL format (basic check for valid hostname)
+  # Skip validation for environment variable references (they'll be validated after expansion)
+  local registry_url_raw="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL}"
+  if [[ ! "$registry_url_raw" =~ ^\$ ]]; then
+    local registry_url="${registry_url_raw}"
+    # Remove http/https prefix for validation
+    registry_url="${registry_url#https://}"
+    registry_url="${registry_url#http://}"
+    
+    if [[ ! "$registry_url" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$ ]] || [[ ${#registry_url} -lt 3 ]] || [[ ${#registry_url} -gt 253 ]]; then
+      log_error "invalid Artifactory registry URL '${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL}' - must be a valid hostname"
+      exit 1
+    fi
+  fi
+
+  # Validate repository name format if provided
+  if [[ -n "${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REPOSITORY:-}" ]]; then
+    local repository="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REPOSITORY}"
+    if [[ ! "$repository" =~ ^[a-z0-9][a-z0-9._/-]*[a-z0-9]$ ]] || [[ ${#repository} -gt 255 ]]; then
+      log_error "invalid Artifactory repository name '${repository}' - must contain only lowercase letters, numbers, periods, underscores, hyphens, and slashes, max 255 characters"
       exit 1
     fi
   fi

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -55,6 +55,8 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/ecr.bash"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/gar.bash"
 # shellcheck source=lib/providers/buildkite.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/buildkite.bash"
+# shellcheck source=lib/providers/artifactory.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/artifactory.bash"
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_CACHE_VERBOSE:-false}" == "true" ]]; then
   set -x
@@ -71,6 +73,9 @@ setup_provider_environment() {
       ;;
     buildkite)
       setup_buildkite_environment
+      ;;
+    artifactory)
+      setup_artifactory_environment
       ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_DOCKER_CACHE_PROVIDER}"
@@ -142,6 +147,9 @@ restore_cache() {
     buildkite)
       restore_buildkite_cache
       ;;
+    artifactory)
+      restore_artifactory_cache
+      ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_DOCKER_CACHE_PROVIDER}"
       ;;
@@ -167,6 +175,9 @@ save_cache() {
       ;;
     buildkite)
       save_buildkite_cache
+      ;;
+    artifactory)
+      save_artifactory_cache
       ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_DOCKER_CACHE_PROVIDER}"

--- a/lib/providers/artifactory.bash
+++ b/lib/providers/artifactory.bash
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+setup_artifactory_environment() {
+  local registry_url_raw="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL:-}"
+  local username_raw="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_USERNAME:-}"
+  local identity_token_raw="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_IDENTITY_TOKEN:-}"
+
+  # Validate required parameters
+  if [[ -z "$registry_url_raw" ]]; then
+    log_error "Artifactory registry URL is required"
+    log_info "Set it via the 'registry-url' parameter in artifactory configuration"
+    exit 1
+  fi
+
+  if [[ -z "$username_raw" ]]; then
+    log_error "Artifactory username is required"
+    log_info "Set it via the 'username' parameter in artifactory configuration"
+    exit 1
+  fi
+
+  if [[ -z "$identity_token_raw" ]]; then
+    log_error "Artifactory identity token is required"
+    log_info "Set it via the 'identity-token' parameter in artifactory configuration"
+    exit 1
+  fi
+
+  # Process environment variable references in parameters
+  local registry_url
+  registry_url=$(expand_env_var "$registry_url_raw" "registry-url")
+
+  local username
+  username=$(expand_env_var "$username_raw" "username")
+
+  local identity_token
+  identity_token=$(expand_env_var "$identity_token_raw" "identity-token")
+
+  # Clean up registry URL (remove protocol if present)
+  registry_url="${registry_url#https://}"
+  registry_url="${registry_url#http://}"
+
+  # Validate expanded registry URL format
+  if [[ ! "$registry_url" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$ ]] || [[ ${#registry_url} -lt 3 ]] || [[ ${#registry_url} -gt 253 ]]; then
+    log_error "invalid Artifactory registry URL '$registry_url' - must be a valid hostname"
+    exit 1
+  fi
+
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL="$registry_url"
+
+  log_info "Artifactory registry URL: $registry_url"
+  log_info "Artifactory username: $username"
+
+  log_info "Authenticating with Artifactory Docker registry..."
+  if docker login "$registry_url" -u "$username" -p "$identity_token"; then
+    log_success "Successfully authenticated with Artifactory"
+  else
+    log_error "Failed to authenticate with Artifactory"
+    log_info "Verify your username and identity token are correct"
+    log_info "Ensure the registry URL is accessible and supports Docker registry API"
+    exit 1
+  fi
+}
+
+restore_artifactory_cache() {
+  local cache_image
+
+  cache_image=$(build_cache_image_name)
+
+  case "${BUILDKITE_PLUGIN_DOCKER_CACHE_STRATEGY:-hybrid}" in
+    "artifact")
+      # Artifact caching - restore complete image or nothing
+      if image_exists_in_registry "$cache_image"; then
+        log_info "Complete cache hit! Restoring from $cache_image"
+        if pull_image "$cache_image"; then
+          tag_image "$cache_image" "${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}"
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="true"
+          log_success "Cache restored successfully from Artifactory"
+          return 0
+        else
+          log_warning "Failed to pull cache image from Artifactory"
+          return 1
+        fi
+      else
+        log_info "Cache miss. No cached image found for key ${BUILDKITE_PLUGIN_DOCKER_CACHE_KEY} in Artifactory."
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="false"
+        return 0
+      fi
+      ;;
+    "build")
+      # Build caching - set up cache-from only
+      if image_exists_in_registry "$cache_image"; then
+        log_info "Build cache available: $cache_image"
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_FROM="$cache_image"
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="false"
+      else
+        log_info "No build cache found for key ${BUILDKITE_PLUGIN_DOCKER_CACHE_KEY} in Artifactory."
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_FROM=""
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="false"
+      fi
+      return 0
+      ;;
+    "hybrid"|*)
+      # Hybrid approach - try complete cache hit first, fall back to build caching
+      if image_exists_in_registry "$cache_image"; then
+        log_info "Complete cache hit! Restoring from $cache_image"
+        if pull_image "$cache_image"; then
+          tag_image "$cache_image" "${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}"
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="true"
+          log_success "Cache restored successfully from Artifactory - build can be skipped"
+          return 0
+        else
+          log_warning "Failed to pull complete cache image, falling back to build caching"
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_FROM="$cache_image"
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="false"
+          return 0
+        fi
+      else
+        log_info "No cache found for key ${BUILDKITE_PLUGIN_DOCKER_CACHE_KEY} - will build from scratch"
+        # Try to find any existing cache image for layer caching by checking for latest tag
+        local repository="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REPOSITORY:-${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}}"
+        local fallback_cache_image="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL}/${repository}/${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}:latest"
+        if image_exists_in_registry "$fallback_cache_image"; then
+          log_info "Using latest cache for layer caching: $fallback_cache_image"
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_FROM="$fallback_cache_image"
+        else
+          export BUILDKITE_PLUGIN_DOCKER_CACHE_FROM=""
+          log_warning "No fallback cache found for layer caching"
+        fi
+        export BUILDKITE_PLUGIN_DOCKER_CACHE_HIT="false"
+        return 0
+      fi
+      ;;
+  esac
+}
+
+save_artifactory_cache() {
+  local cache_image
+
+  # Skip save if we had a complete cache hit (image wasn't rebuilt)
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_CACHE_HIT:-false}" == "true" ]]; then
+    log_info "Cache was restored from complete image - no need to save"
+    return 0
+  fi
+
+  cache_image=$(build_cache_image_name)
+
+  if ! image_exists_locally "${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}"; then
+    case "${BUILDKITE_PLUGIN_DOCKER_CACHE_STRATEGY:-hybrid}" in
+      "artifact")
+        log_error "Source image not found locally: ${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}"
+        return 1
+        ;;
+      "build"|"hybrid"|*)
+        log_warning "Source image not found locally: ${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE} - this is expected if build was skipped or failed"
+        return 0
+        ;;
+    esac
+  fi
+
+  # Build cache image name with latest tag for layer caching
+  local repository="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REPOSITORY:-${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}}"
+  local latest_image="${BUILDKITE_PLUGIN_DOCKER_CACHE_ARTIFACTORY_REGISTRY_URL}/${repository}/${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}:latest"
+
+  if tag_image "${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}" "$cache_image"; then
+    if push_image "$cache_image"; then
+      log_success "Cache saved successfully to Artifactory: $cache_image"
+
+      # Also tag and push as :latest for layer caching fallback
+      if tag_image "${BUILDKITE_PLUGIN_DOCKER_CACHE_IMAGE}" "$latest_image"; then
+        if push_image "$latest_image"; then
+          log_success "Latest tag saved for layer caching: $latest_image"
+        else
+          log_warning "Failed to push latest tag (cache still saved)"
+        fi
+      else
+        log_warning "Failed to tag latest image (cache still saved)"
+      fi
+
+      return 0
+    else
+      log_error "Failed to save cache to Artifactory"
+      return 1
+    fi
+  else
+    log_error "Failed to tag cache image for Artifactory"
+    return 1
+  fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: Docker-Cache
-description: Cache Docker images across builds using various registry providers (ECR, GAR, and Buildkite Packages currently supported)
+description: Cache Docker images across builds using various registry providers (ECR, GAR, Buildkite Packages, and Artifactory Docker Registry currently supported)
 author: https://github.com/buildkite-plugins
 requirements:
   - bash
@@ -8,7 +8,7 @@ configuration:
   properties:
     provider:
       type: string
-      enum: [ecr, gar, buildkite]
+      enum: [ecr, gar, buildkite, artifactory]
       description: Registry provider type
     image:
       type: string
@@ -119,6 +119,27 @@ configuration:
         api-token:
           type: string
           description: Buildkite API token with Read Packages and Write Packages scopes (required when auth-method is api-token)
+      additionalProperties: false
+    artifactory:
+      type: object
+      description: Artifactory Docker Registry configuration
+      properties:
+        registry-url:
+          type: string
+          description: Artifactory registry URL (e.g., "myjfroginstance.jfrog.io")
+        username:
+          type: string
+          description: Username (typically email address) for Artifactory authentication
+        identity-token:
+          type: string
+          description: Artifactory identity token for authentication
+        repository:
+          type: string
+          description: Artifactory repository name (defaults to the image name when omitted)
+      required:
+        - registry-url
+        - username
+        - identity-token
       additionalProperties: false
     verbose:
       type: boolean


### PR DESCRIPTION
Creates new `artifactory` provider that allows using a JFrog Artifactory Docker Registry for caching Docker images across builds.